### PR TITLE
Add shortcut to save and preview

### DIFF
--- a/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
+++ b/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
@@ -14,8 +14,8 @@ export class EditorPreviewCommand implements ICommand {
   readonly icon = new CodIcon('open-preview');
   readonly label = 'Prévisualiser';
   readonly keybinding = new Keybinding({
-    key: KeyCodes.P,
-    label: '⌘ P',
+    key: KeyCodes.ENTER,
+    label: '⌘ ENTER',
     modifiers: [KeyModifiers.CTRL_CMD],
   });
 

--- a/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
+++ b/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CodIcon } from '@cisstech/nge/ui/icon';
-import { ICommand } from '../../commands';
+import { ICommand, Keybinding } from '../../commands';
+import { KeyCodes, KeyModifiers } from '../../keybinding';
 import { EditorService } from '../editor.service';
 import { PreviewService } from '../preview.service';
 
@@ -12,6 +13,11 @@ export class EditorPreviewCommand implements ICommand {
   readonly id = EDITOR_PREVIEW_COMMAND;
   readonly icon = new CodIcon('open-preview');
   readonly label = 'Prévisualiser';
+  readonly keybinding = new Keybinding({
+    key: KeyCodes.P,
+    label: '⌘ P',
+    modifiers: [KeyModifiers.CTRL_CMD],
+  });
 
   get enabled(): boolean {
     const { activeGroup } = this.editorService;
@@ -23,8 +29,8 @@ export class EditorPreviewCommand implements ICommand {
       return false;
     }
 
+    this.editorService.saveActiveResource()
     return (
-      !activeGroup.isInPreviewMode &&
       this.previewService.canHandle(activeResource)
     );
   }
@@ -62,7 +68,7 @@ export class EditorPreviewReloadCommand implements ICommand {
     if (!activeResource) {
       return false;
     }
-
+    
     return (activeGroup.isInPreviewMode &&
       this.previewService.canHandle(activeResource)
     );

--- a/projects/nge-ide/core/src/editors/monaco.service.ts
+++ b/projects/nge-ide/core/src/editors/monaco.service.ts
@@ -17,6 +17,7 @@ import {
   ACTION_INSERT_CURSOR_ABOVE,
   ACTION_INSERT_CURSOR_AT_END_OF_EACH_LINE_SELECTED,
   ACTION_INSERT_CURSOR_BELOW,
+  ACTION_INSERT_LINE_AFTER,
   ACTION_JUMP_TO_BRACKET,
   ACTION_MARKER_NEXT,
   ACTION_MARKER_PREV,
@@ -138,6 +139,7 @@ export class MonacoService implements IContribution {
   async activate(): Promise<void> {
     await this.registerToolbarItems();
     this.registerStatusBarItems();
+    this.registerEditorShortcuts();
 
     this.subscriptions.push(
       this.fileService.onDidCloseFile.subscribe(this.disposeModel.bind(this))
@@ -418,6 +420,14 @@ export class MonacoService implements IContribution {
     });
   }
 
+  private registerEditorShortcuts() {
+    monaco.editor.addKeybindingRule({
+      keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+      command: null, 
+      when: null,
+    });
+  }
+
   private onDidChangeCursorPosition(
     event: monaco.editor.ICursorPositionChangedEvent,
     editor: monaco.editor.IStandaloneCodeEditor
@@ -677,7 +687,7 @@ export class MonacoService implements IContribution {
     registerEditorAction(ACTION_JUMP_TO_BRACKET, ToolbarGroups.GO, 20, true);
     registerEditorAction(ACTION_MARKER_NEXT, ToolbarGroups.GO, 30);
     registerEditorAction(ACTION_MARKER_PREV, ToolbarGroups.GO, 30, true);
-
+   
     n.remove();
     e.dispose();
   }


### PR DESCRIPTION
This PR includes the implementation of a keyboard shortcut for saving and previewing a page. This enhancement aims to streamline the workflow by allowing users to quickly save their work and see the preview without having to navigate through multiple shortcuts or logos.