### PR TITLE
Sidebar settings

### DIFF
--- a/projects/nge-ide/core/src/settings/settings.model.ts
+++ b/projects/nge-ide/core/src/settings/settings.model.ts
@@ -715,5 +715,13 @@ export namespace Settings {
       comment:
         'Annotates each line in the focused file with information from the revision which last modified the line.',
     },
+    {
+      name: 'toggleSideBar',
+      group: 'ide.layout',
+      type: Types.Dropdown,
+      value: 'opened',
+      choices: ['closed', 'opened'],
+      comment: 'Controls whether the sidebar is opened or closed by default.',
+    }
   ];
 }

--- a/projects/nge-ide/src/sidebar/sidebar.component.ts
+++ b/projects/nge-ide/src/sidebar/sidebar.component.ts
@@ -82,7 +82,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.settingsService.activate();
     this.restoreState()
       .then(() => {
         this.subscriptions.push(
@@ -93,9 +92,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
         );
 
         this.subscriptions.push(
+          this.ideService.onAfterStart(this.restoreState.bind(this)),
           this.ideService.onBeforeStop(this.saveState.bind(this))
         );
-
+        
         this.subscriptions.push(
           this.viewContainerService.onDidOpen().subscribe((containerId) => {
             const container =
@@ -113,7 +113,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.saveState();
     this.subscriptions.forEach((s) => s.unsubscribe());
-    this.settingsService.deactivate();
   }
 
   trackById(_: number, item: any): string {
@@ -173,7 +172,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   private async restoreState(): Promise<void> {
     const defaultSizeSetting = this.settingsService.get('ide.layout', 'toggleSideBar')?.value;
-    const defaultSize = defaultSizeSetting === 'opened' ? OPENED_SIZE : CLOSED_SIZE;
+    const defaultSize = defaultSizeSetting === 'closed' ? CLOSED_SIZE : OPENED_SIZE;
     this.size = defaultSize;
 
     this.state = await lastValueFrom(

--- a/projects/nge-ide/src/workbench/workbench.component.html
+++ b/projects/nge-ide/src/workbench/workbench.component.html
@@ -31,7 +31,7 @@
                     [icon]="tab.options.title | iconFile"
                   />
                 </ng-template>
-                <span class="tab-title" [nz-tooltip]="tab.options.tooltip" nzTooltipPlacement="top">{{
+                <span class="tab-title" [nz-tooltip]="tab.options.tooltip" [nzTooltipPlacement]="['top', 'bottom']">{{
                   tab.options.title
                 }}</span>
                 <span *ngIf="tab.file?.readOnly" class="codicon codicon-lock-small" nz-tooltip="Éditeur en lecture seule"></span>

--- a/projects/nge-ide/src/workbench/workbench.component.scss
+++ b/projects/nge-ide/src/workbench/workbench.component.scss
@@ -46,7 +46,6 @@
 .tab-dirty,
 .tab-close {
   margin: 0 4px;
-  padding-right: 1px;
 }
 
 .tab-dirty:hover,

--- a/projects/nge-ide/src/workbench/workbench.component.scss
+++ b/projects/nge-ide/src/workbench/workbench.component.scss
@@ -46,11 +46,12 @@
 .tab-dirty,
 .tab-close {
   margin: 0 4px;
+  padding-right: 1px;
 }
 
 .tab-dirty:hover,
 .tab-close:hover {
-  border: 1px solid;
+  outline: 1px solid;
   border-radius: 8px;
 }
 


### PR DESCRIPTION
I noticed that there was no functionality to open or close the explorer by default.

To address this, I implemented a feature that allows users to choose whether the explorer is extended or folded by default, through the settings. 
Please let me know if it suits to you.
(By default, it's still opened) 

![image](https://github.com/cisstech/nge-ide/assets/101347535/2aecbd03-c887-4621-9209-45abfb57858f)
