### PR TITLE
Remove preview shortcut

### DIFF
--- a/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
+++ b/projects/nge-ide/core/src/editors/commands/editor-preview.command.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core'
 import { CodIcon } from '@cisstech/nge/ui/icon'
-import { ICommand, Keybinding } from '../../commands'
-import { KeyCodes, KeyModifiers } from '../../keybinding'
+import { ICommand } from '../../commands'
 import { EditorService } from '../editor.service'
 import { PreviewService } from '../preview.service'
 
@@ -13,11 +12,6 @@ export class EditorPreviewCommand implements ICommand {
   readonly id = EDITOR_PREVIEW_COMMAND
   readonly icon = new CodIcon('open-preview')
   readonly label = 'Prévisualiser'
-  readonly keybinding = new Keybinding({
-    key: KeyCodes.ENTER,
-    label: '⌘ ENTER',
-    modifiers: [KeyModifiers.CTRL_CMD],
-  })
 
   get enabled(): boolean {
     const { activeGroup } = this.editorService


### PR DESCRIPTION
This change disables the preview shortcut in nge-ide, as we are relying on a global shortcut directly on PLaTOn. Keeping the shortcut active in the IDE causes the event to be intercepted, leading to conflicts. 

This update ensures compatibility with PLaTOn's global behavior.