### PR TITLE
fix(editor): keep one editor in the DOM and focus a neighbour on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [18.1.1](https://github.com/cisstech/nge-ide/compare/v18.1.0...v18.1.1) (2026-07-10)
+
+
+### Bug Fixes
+
+* **editor:** keep a single editor in the DOM when switching editors ([#442](https://github.com/cisstech/nge-ide/issues/442))
+* **editor:** focus a neighbouring tab when the active tab is closed
+* **editor:** destroy cached editor components on directive teardown
+
 ## 18.1.0 (2025-03-04)
 
 ### [18.0.1](https://github.com/cisstech/nge-ide/compare/v18.0.0...v18.0.1) (2025-02-04)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisstech/nge-ide",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "description": "An extensible and flexible open source ide written in Angular.",
   "keywords": [
     "angular"

--- a/projects/nge-ide/core/src/directives/editor.directive.ts
+++ b/projects/nge-ide/core/src/directives/editor.directive.ts
@@ -15,6 +15,14 @@ export class EditorDirective implements OnChanges, OnDestroy {
 
   async ngOnChanges(): Promise<void> {
     if (this.editor) {
+      // Always detach the currently displayed editor before showing the target
+      // one. Otherwise opening an editor that has not been rendered yet (e.g. a
+      // custom editor on top of a code editor) would append its component while
+      // the previous one stays in the container, leaving two editors in the DOM.
+      while (this.viewContainerRef.length > 0) {
+        this.viewContainerRef.detach()
+      }
+
       let componentRef = this.componentRefs.get(this.editor.id)
       if (!componentRef) {
         componentRef = await this.compiler.render({
@@ -24,15 +32,15 @@ export class EditorDirective implements OnChanges, OnDestroy {
         })
         this.componentRefs.set(this.editor.id, componentRef)
       } else {
-        while (this.viewContainerRef.length > 0) {
-          this.viewContainerRef.detach()
-        }
         this.viewContainerRef.insert(componentRef.hostView)
       }
     }
   }
 
   ngOnDestroy(): void {
-    Object.values(this.componentRefs).forEach((componentRef) => componentRef.destroy())
+    // componentRefs is a Map, so iterate it directly: Object.values() on a Map
+    // returns [] and would leak every cached editor component.
+    this.componentRefs.forEach((componentRef) => componentRef.destroy())
+    this.componentRefs.clear()
   }
 }

--- a/projects/nge-ide/core/src/editors/editor.service.ts
+++ b/projects/nge-ide/core/src/editors/editor.service.ts
@@ -353,13 +353,19 @@ export class EditorService implements IContribution {
 
     this.editorGroups$.next(this.listGroups())
 
-    this.state$.next(this.emptyEditorState())
+    if (!group.isEmpty) {
+      // close() keeps (or re-selects) the group's active editor after a tab is
+      // removed, so reflect it instead of emptying the workbench.
+      this.setActiveGroup(group)
+      return
+    }
 
-    if (group.isEmpty) {
-      const randomGroup = this.findGroup((g) => !g.isEmpty)
-      if (randomGroup) {
-        this.setActiveGroup(randomGroup)
-      }
+    // The group is now empty: fall back to another non-empty group, or clear.
+    const randomGroup = this.findGroup((g) => !g.isEmpty)
+    if (randomGroup) {
+      this.setActiveGroup(randomGroup)
+    } else {
+      this.state$.next(this.emptyEditorState())
     }
   }
 

--- a/projects/nge-ide/core/src/editors/editor.ts
+++ b/projects/nge-ide/core/src/editors/editor.ts
@@ -281,7 +281,7 @@ export class EditorGroup {
     const index = this.findIndex(resource)
     if (index === -1) return false
 
-    let tab = this._tabs[index]
+    const tab = this._tabs[index]
     const closeable =
       force || // close if forced
       tab.options.preview || // preview resource is always closeable
@@ -289,15 +289,32 @@ export class EditorGroup {
 
     if (!closeable) return false
 
+    const wasActive = this.isActive(resource)
+    const activeResource = this.activeResource
     this._tabs.splice(index, 1)
 
-    if (this.isEmpty || this.isActive(resource)) {
+    if (this.isEmpty) {
       this._request = undefined
       this._activeIndex = -1
       this._activeEditor = undefined
+      this.closed(this, tab.resource, !!tab.options.preview)
+    } else if (wasActive) {
+      // The active tab was closed but others remain: focus the neighbour (the
+      // tab that shifted into its place, or the new last one) so the group is
+      // never left without a focused editor.
+      this._request = undefined
+      this._activeIndex = -1
+      this._activeEditor = undefined
+      const next = this._tabs[Math.min(index, this._tabs.length - 1)]
+      await this.open(next.resource, next.options).catch(() => undefined)
+      this.closed(this, tab.resource, !!tab.options.preview)
+    } else {
+      // A background tab was closed: keep the active one and fix its shifted index.
+      if (activeResource) {
+        this._activeIndex = this.findIndex(activeResource)
+      }
+      this.closed(this, tab.resource, !!tab.options.preview)
     }
-
-    this.closed(this, tab.resource, !!tab.options.preview)
 
     return true
   }


### PR DESCRIPTION


Fixes two editor-workbench bugs, branched from `main` so it can ship as an independent v18 patch (and fold into v22 later).

## 1. Two editors in the DOM (#442)

Opening an editor that hasn't been rendered yet (e.g. the settings editor on top of a code editor) appended its component **without detaching** the current one, leaving two editors in `.editor-wrapper`; pressing <kbd>Tab</kbd> then broke the layout. `EditorDirective` now always detaches the displayed editor before rendering/inserting the target one (lifting the detach loop out of the `if/else`, as suggested in the issue).

Also fixes `ngOnDestroy` leaking every cached editor: it iterated `Object.values(map)` which is always `[]` for a `Map`.

## 2. Closing a tab left the workbench empty

`EditorGroup.close()` cleared the active state without selecting a successor, and the close handler reset to an empty state regardless of remaining tabs, so closing **any** tab unfocused the editor. Now:
- `close()` activates the neighbouring tab when the active one is closed, and keeps focus (fixing the shifted index) when a background tab is closed;
- the close handler reflects the group's active editor instead of emptying the workbench, falling back to another group (or empty) only when the group is truly empty.

Verified: build, lint and tests pass on `main` (Angular 18).

Closes #442

## Before


https://github.com/user-attachments/assets/a43e0743-c4e0-4c73-b7c1-376695ac47a2


## After

https://github.com/user-attachments/assets/ecda94ae-5045-4c80-b8f0-4696ee7967b9

