### PR TITLE
chore(demo): bump @cisstech/nge to 22.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@angular/platform-browser": "^22.0.6",
     "@angular/platform-browser-dynamic": "^22.0.6",
     "@angular/router": "^22.0.6",
-    "@cisstech/nge": "^22.4.2",
+    "@cisstech/nge": "^22.4.3",
     "@ngx-pwa/local-storage": "^18.0.0",
     "angular-split": "^20.0.0",
     "marked": "^11.0.1",

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -22,10 +22,10 @@ import {
   withIcons,
   withKatex,
   withLinkAnchor,
-  withShiki,
   withTabbedSet,
   withThemes,
 } from '@cisstech/nge/markdown'
+import { withShiki } from '@cisstech/nge/markdown/shiki'
 import { NGE_MONACO_THEMES, provideNgeMonaco } from '@cisstech/nge/monaco'
 
 // MODULE

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,7 +2552,7 @@ __metadata:
     "@angular/platform-server": "npm:^22.0.6"
     "@angular/router": "npm:^22.0.6"
     "@angular/ssr": "npm:^22.0.6"
-    "@cisstech/nge": "npm:^22.4.2"
+    "@cisstech/nge": "npm:^22.4.3"
     "@commitlint/cli": "npm:^19.4.0"
     "@commitlint/config-conventional": "npm:^19.2.2"
     "@ngx-pwa/local-storage": "npm:^18.0.0"
@@ -2597,9 +2597,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cisstech/nge@npm:^22.4.2":
-  version: 22.4.2
-  resolution: "@cisstech/nge@npm:22.4.2"
+"@cisstech/nge@npm:^22.4.3":
+  version: 22.4.3
+  resolution: "@cisstech/nge@npm:22.4.3"
   dependencies:
     marked: "npm:^11.0.1"
     tslib: "npm:^2.3.0"
@@ -2627,7 +2627,7 @@ __metadata:
       optional: true
     typedoc:
       optional: true
-  checksum: 10c0/d379de7947b855e15b08f6a3cd4aa70326e8c1970ecc723b2b3190b5b902960099197c8bf8bcbba65bcf427ee620df9d1a572fdf59ba8f425ecc902a8da0244e
+  checksum: 10c0/24dcb33a622e22a0962f630a279695d306b0e83f3d7d95afb7f58afd16833fb4029501306ac3fee37609ba4cabf3509507e775c12c934c8fff333ad64d88b726
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps @cisstech/nge to 22.4.3 and moves the `withShiki` import to its new entry point `@cisstech/nge/markdown/shiki`. Build, prerender (226 routes), and lint all pass.