### PR TITLE
fix(editor): allow an editor and a preview to be displayed in the same group

### DIFF
--- a/projects/nge-ide/core/src/editors/commands/editor-close-command.ts
+++ b/projects/nge-ide/core/src/editors/commands/editor-close-command.ts
@@ -25,7 +25,11 @@ export class EditorCloseCommand implements ICommand {
 
   async execute(): Promise<void> {
     if (this.editorService.activeResource) {
-      this.editorService.close(this.editorService.activeResource)
+      this.editorService.close(
+        this.editorService.activeResource,
+        false,
+        this.editorService.activeGroup?.isInPreviewMode
+      )
     }
   }
 }

--- a/projects/nge-ide/core/src/editors/editor.service.ts
+++ b/projects/nge-ide/core/src/editors/editor.service.ts
@@ -258,10 +258,27 @@ export class EditorService implements IContribution {
    * Closes the resource from all the editor groups.
    * @param resource the resource to close.
    * @param force When `true`, force close the resource without asking to save it if it is dirty.
+   * @param isPreview if defined, close the resource only if it is opened as a preview or not depending on the value of this parameter.
    */
-  async close(resource: monaco.Uri, force?: boolean): Promise<any> {
-    const groups = this.findGroups((group) => group.contains(resource))
-    return Promise.all(groups.map((g) => g.close(resource, force)))
+  async close(resource: monaco.Uri, force?: boolean, isPreview?: boolean): Promise<any> {
+    const groups = this.findGroups((group) => group.contains(resource, isPreview))
+
+    return Promise.all(
+      groups.map(async (group) => {
+        if (isPreview === undefined) {
+          // When isPreview is undefined, we want to close the resource whether it is opened as a preview or not.
+          // So we need to close it until it is no longer opened in the group.
+          while (await group.close(resource, force)) {
+            if (!group.contains(resource)) {
+              break
+            }
+          }
+          return
+        }
+
+        await group.close(resource, force, isPreview)
+      })
+    )
   }
 
   /**

--- a/projects/nge-ide/core/src/editors/editor.ts
+++ b/projects/nge-ide/core/src/editors/editor.ts
@@ -180,9 +180,10 @@ export class EditorGroup {
    * @param isPreview if `true`, check if the resource is opened as a preview.
    * @throws {ReferenceError} if any of the arguments is null.
    */
-  contains(resource: monaco.Uri): boolean {
+  contains(resource: monaco.Uri, isPreview?: boolean): boolean {
     return this._tabs.some((e) => {
       return e.resource.toString(true) === resource.toString(true)
+        && (isPreview === undefined || isPreview === !!e.options.preview)
     })
   }
 
@@ -202,8 +203,8 @@ export class EditorGroup {
    * @param resource the resource.
    * @throws {ReferenceError} if any of the arguments is null.
    */
-  isActive(resource: monaco.Uri): boolean {
-    return this.activeResource?.toString(true) === resource.toString(true)
+  isActive(resource: monaco.Uri, isPreview?: boolean): boolean {
+    return this.activeResource?.toString(true) === resource.toString(true) && (isPreview === undefined || isPreview === !!this._request?.options.preview)
   }
 
   /**
@@ -211,9 +212,9 @@ export class EditorGroup {
    * @param resource the resource to check the index for.
    * @returns The index of the resource or `-1` if the resource is not opened.
    */
-  findIndex(resource: monaco.Uri): number {
+  findIndex(resource: monaco.Uri, isPreview?: boolean): number {
     return this._tabs.findIndex((e) => {
-      return e.resource.toString(true) === resource.toString(true)
+      return e.resource.toString(true) === resource.toString(true) && (isPreview === undefined || isPreview === !!e.options.preview)
     })
   }
 
@@ -229,7 +230,7 @@ export class EditorGroup {
    * @returns An promise that resolve once the resource is opened.
    */
   async open(resource: monaco.Uri, options: OpenOptions): Promise<void> {
-    if (this.isActive(resource) && !options.preview) return
+    if (this.isActive(resource, !!options.preview) && !options.preview) return
 
     this.fileService = this.fileService || this.injector.get(FileService)
 
@@ -253,12 +254,12 @@ export class EditorGroup {
       throw new Error(`There is no registered editor to open "${request.uri}"`)
     }
 
-    if (!this.contains(resource)) {
+    if (!this.contains(resource, !!options.preview)) {
       this._tabs.push({ options, resource, file })
     }
 
     this._request = request
-    this._activeIndex = this.findIndex(resource)
+    this._activeIndex = this.findIndex(resource, !!options.preview)
     this._activeEditor = editor
     this._history.push(this._tabs[this._activeIndex])
 
@@ -277,8 +278,8 @@ export class EditorGroup {
    * @throws {ReferenceError} if any of the arguments is null.
    * @returns A promise that resolve with `true` if the resource is removed `false` otherwise.
    */
-  async close(resource: monaco.Uri, force?: boolean): Promise<boolean> {
-    const index = this.findIndex(resource)
+  async close(resource: monaco.Uri, force?: boolean, isPreview?: boolean): Promise<boolean> {
+    const index = this.findIndex(resource, isPreview)
     if (index === -1) return false
 
     const tab = this._tabs[index]
@@ -289,8 +290,8 @@ export class EditorGroup {
 
     if (!closeable) return false
 
-    const wasActive = this.isActive(resource)
-    const activeResource = this.activeResource
+    const activeIndex = this._activeIndex
+    const wasActive = activeIndex === index
     this._tabs.splice(index, 1)
 
     if (this.isEmpty) {
@@ -309,10 +310,9 @@ export class EditorGroup {
       await this.open(next.resource, next.options).catch(() => undefined)
       this.closed(this, tab.resource, !!tab.options.preview)
     } else {
-      // A background tab was closed: keep the active one and fix its shifted index.
-      if (activeResource) {
-        this._activeIndex = this.findIndex(activeResource)
-      }
+      // A background tab was closed: keep the active tab selected and shift its
+      // index only when the removed tab was before it.
+      this._activeIndex = index < activeIndex ? activeIndex - 1 : activeIndex
       this.closed(this, tab.resource, !!tab.options.preview)
     }
 

--- a/projects/nge-ide/src/workbench/workbench.component.html
+++ b/projects/nge-ide/src/workbench/workbench.component.html
@@ -28,9 +28,15 @@
                   <span class="codicon codicon-lock-small" ideTooltip="Éditeur en lecture seule"></span>
                 }
                 @if (tab.resource | fileChanged | async) {
-                  <span class="tab-dirty codicon codicon-close-dirty" (click)="group.close(tab.resource)"></span>
+                  <span
+                    class="tab-dirty codicon codicon-close-dirty"
+                    (click)="group.close(tab.resource, undefined, !!tab.options.preview)"
+                  ></span>
                 } @else {
-                  <span class="tab-close codicon codicon-close" (click)="group.close(tab.resource)"></span>
+                  <span
+                    class="tab-close codicon codicon-close"
+                    (click)="group.close(tab.resource, undefined, !!tab.options.preview)"
+                  ></span>
                 }
               </div>
             </ng-template>

--- a/projects/nge-ide/src/workbench/workbench.component.ts
+++ b/projects/nge-ide/src/workbench/workbench.component.ts
@@ -48,7 +48,7 @@ export class WorkbenchComponent implements OnInit, OnDestroy {
   }
 
   trackTab(_: number, item: EditorTab) {
-    return item.resource.toString(true)
+    return `${item.resource.toString(true)}-${item.options.preview ? 'preview' : 'editor'}`
   }
 
   trackGroup(_: number, item: EditorGroup) {


### PR DESCRIPTION
Fonctionnement actuel, un éditeur et une preview ne peuvent pas être affichés dans le même groupe, de plus le fait d'essayer de le faire créer un état incohérent. (Code comme si on éditeur le fichier mais nom de l'onglet "Preview: ...." )

https://github.com/user-attachments/assets/b92f84f4-c121-4b90-b862-c01616ac0715

Avec cette PR le problème n'est plus présent, on peut très bien avoir une preview et un éditeur dans le même groupe.

https://github.com/user-attachments/assets/b9fd7d07-07f5-49fc-abc0-9b56b151bee9